### PR TITLE
fixes error on import of non-existent module

### DIFF
--- a/d3m_croc/d3m_croc.py
+++ b/d3m_croc/d3m_croc.py
@@ -15,9 +15,6 @@ from keras.preprocessing import image
 from keras.applications.inception_v3 \
     import InceptionV3, decode_predictions, preprocess_input
 
-from nk_croc.is_a import isa_dict
-from nk_croc.id_mapping import id_mapping_dict
-
 requests_session = requests.Session() if os.environ.get('USE_REQUESTS_SESSION') == "True" else requests
 
 class Croc():


### PR DESCRIPTION
Fixes import error in d3m_croc.py:

```shell
from nk_croc.is_a import isa_dict
ModuleNotFoundError: No module named 'nk_croc'
```
